### PR TITLE
Evitar que se expongan tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 logs/
+Sandy bot/logs/
 .venv/
 .env
 Sandy bot/data/contador_diario.json

--- a/Sandy bot/sandybot/logging_config.py
+++ b/Sandy bot/sandybot/logging_config.py
@@ -2,8 +2,20 @@
 # Ubicación de archivo: Sandy bot/sandybot/logging_config.py
 # User-provided custom instructions
 import logging
+import re
 from logging.handlers import RotatingFileHandler
 from .config import config
+
+
+class SecretFilter(logging.Filter):
+    """Oculta tokens presentes en los mensajes."""
+
+    _token_pattern = re.compile(r"bot\d+:[A-Za-z0-9_-]+")
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        if isinstance(record.msg, str):
+            record.msg = self._token_pattern.sub("bot*****:TOKEN", record.msg)
+        return True
 
 
 def setup_logging(level: int = logging.INFO) -> None:
@@ -15,6 +27,7 @@ def setup_logging(level: int = logging.INFO) -> None:
     root = logging.getLogger()
     root.setLevel(level)
     root.handlers.clear()
+    root.addFilter(SecretFilter())
 
     # Evitar que bibliotecas como httpx registren tokens o datos sensibles
     logging.getLogger("httpx").setLevel(logging.WARNING)


### PR DESCRIPTION
## Resumen
- se ignoró la carpeta de logs del bot
- se agregó un filtro de logging para ocultar tokens en cualquier mensaje

## Testing
- `pytest -q` *(falló: ModuleNotFoundError para varias dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_6888af2cdfc083308077b619f3932ddc